### PR TITLE
feat(sprinkle): persistent watering timer via HA timer entity

### DIFF
--- a/packages/sprinkle/README.md
+++ b/packages/sprinkle/README.md
@@ -110,6 +110,7 @@ device_status_entity: sensor.garden_water_valve_current_device_status
 auto_close_entity: switch.garden_water_valve_auto_close_when_water_shortage
 timed_irrigation_entity: sensor.garden_water_valve_cyclic_timed_irrigation
 quantitative_irrigation_entity: sensor.garden_water_valve_cyclic_quantitative_irrigation
+timer_entity: timer.garden_watering
 volume_max: 25
 duration_max: 15
 weather_entity: weather.home
@@ -129,9 +130,46 @@ weather_entity: weather.home
 | `auto_close_entity` | string | No | - | Entity ID for auto-close when water shortage feature |
 | `timed_irrigation_entity` | string | No | - | Entity ID for duration-based irrigation sensor |
 | `quantitative_irrigation_entity` | string | No | - | Entity ID for volume-based irrigation sensor |
+| `timer_entity` | string | No | - | Entity ID of an HA `timer` helper backing the watering countdown (see below) |
 | `volume_max` | number | No | 50 | Maximum volume in liters (1-100) |
 | `duration_max` | number | No | 30 | Maximum duration in minutes (1-60) |
 | `weather_entity` | string | No | - | Entity ID for weather information display |
+
+### Persistent Watering Timer (`timer_entity`)
+
+When `timer_entity` points to a Home Assistant [timer helper](https://www.home-assistant.io/integrations/timer/), duration-based watering becomes a first-class HA entity:
+
+- starting a timed watering also starts the timer (`timer.start` with the chosen duration); stopping the valve cancels it
+- both the compact card and the more-info dialog show a countdown ticking from the timer's server-side `finishes_at` — every device stays in sync, and the countdown survives page reloads
+- the timer entity is available to automations and history like any other entity
+
+Define one timer per valve, e.g.:
+
+```yaml
+timer:
+  garden_watering:
+    name: Garden watering
+    restore: true
+```
+
+Recommended companion automation, so the timer is cancelled when the valve closes for any other reason (physical stop, Zigbee2MQTT schedule, another automation):
+
+```yaml
+automation:
+  - alias: Cancel garden watering timer when valve closes
+    triggers:
+      - trigger: state
+        entity_id: switch.garden_water_valve
+        to: "off"
+    actions:
+      - action: timer.cancel
+        target:
+          entity_id: timer.garden_watering
+```
+
+Notes:
+- the timer applies to **duration-based** watering started from the card; volume-based watering and externally-started runs don't start it (the more-info dialog still falls back to the computed countdown for external timed runs)
+- without `timer_entity`, the card behaves exactly as before
 
 ### Multiple Valve Setup
 

--- a/packages/sprinkle/src/card.ts
+++ b/packages/sprinkle/src/card.ts
@@ -5,7 +5,7 @@ import { fireEvent } from './utils/fireEvent';
 import { MoreInfoDialogParams } from './types/lovelace';
 import { customElement, property, state } from 'lit/decorators.js';
 import { HomeAssistantService } from './services/ha-service';
-import { ValveService } from './services/valve-service';
+import { CountDown, ValveService } from './services/valve-service';
 import { ConfigRegistry } from './services/SprinkleConfigRegistry';
 import './containers/watering-container';
 import './components/card-mini';
@@ -24,7 +24,11 @@ export class SprinkleCard extends LitElement {
   @state()
   valveService: ValveService | null = null
 
+  @state()
+  countdown: CountDown | null = null;
+
   private configRegistry = ConfigRegistry.getInstance();
+  private countdownInterval?: number;
 
   setConfig(config: SprinkleConfig) {
     if (!config) {
@@ -52,19 +56,47 @@ export class SprinkleCard extends LitElement {
     }
     
     this.initializeServices();
+    this.updateCountdown();
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    
+
     if (this.config?.valve_entity) {
       this.configRegistry.deleteConfig(this.config.valve_entity);
     }
+    this.stopCountdownTicking();
   }
 
   updated(changedProps: Map<string, unknown>) {
     if ((changedProps.has('hass') || changedProps.has('config'))) {
       this.initializeServices();
+      this.updateCountdown();
+    }
+  }
+
+  /**
+   * Refreshes the mini-card countdown from the HA timer entity and keeps a
+   * single 1s ticker running only while the countdown is active. Reads
+   * this.valveService fresh on every tick — services are recreated on every
+   * hass update.
+   */
+  private updateCountdown(): void {
+    this.countdown = this.valveService?.getTimerCountdown() ?? null;
+
+    if (this.countdown && this.countdownInterval === undefined) {
+      this.countdownInterval = window.setInterval(() => {
+        this.updateCountdown();
+      }, 1000);
+    } else if (!this.countdown) {
+      this.stopCountdownTicking();
+    }
+  }
+
+  private stopCountdownTicking(): void {
+    if (this.countdownInterval !== undefined) {
+      clearInterval(this.countdownInterval);
+      this.countdownInterval = undefined;
     }
   }
 
@@ -113,6 +145,7 @@ export class SprinkleCard extends LitElement {
           .status="${statusEntity?.state ?? ''}"
           .batteryLevel="${batteryLevel}"
           .flowRate="${this.valveService?.flowRate ?? null}"
+          .countdown="${this.countdown}"
           @click="${this.handleShowMoreInfo}"
           @toggle-valve="${this.handleToggleValve}"
           @valve-toggle-failed="${this.handleToggleFailed}"

--- a/packages/sprinkle/src/components/__tests__/card-mini.test.ts
+++ b/packages/sprinkle/src/components/__tests__/card-mini.test.ts
@@ -1,0 +1,87 @@
+import { LitTestKit } from '../../test/Testkit';
+
+import { SprinkleCardMini } from '../card-mini';
+import { CountDown } from '../../services/valve-service';
+import { html } from 'lit';
+import '../card-mini';
+
+describe('SprinkleCardMini countdown', () => {
+  const driver = new LitTestKit<SprinkleCardMini, {
+    countdown: string;
+    countdownTime: string;
+    progressFill: string;
+    stateLabel: string;
+  }>({
+    countdown: '.mini-countdown',
+    countdownTime: '.mini-countdown-time',
+    progressFill: '.mini-progress-fill',
+    stateLabel: '.button-container > span',
+  });
+
+  const activeCountdown: CountDown = {
+    secondsRemaining: 45,
+    totalDuration: 90,
+    formatted: '00:45',
+    progress: 50,
+    isActive: true,
+  };
+
+  const inactiveCountdown: CountDown = {
+    secondsRemaining: 0,
+    totalDuration: 0,
+    formatted: '--:--',
+    progress: 0,
+    isActive: false,
+  };
+
+  beforeEach(() => {
+    driver.reset();
+  });
+
+  it('renders the valve state label when no countdown is set', async () => {
+    await driver.render(
+      html`<sprinkle-status-card .valveSwitchState=${'off'}></sprinkle-status-card>`
+    );
+
+    expect(driver.finders.stateLabel().text()?.trim()).toBe('off');
+    expect(driver.finders.countdown().exists()).toBe(false);
+  });
+
+  it('renders the valve state label when the countdown is inactive', async () => {
+    await driver.render(
+      html`<sprinkle-status-card
+        .valveSwitchState=${'off'}
+        .countdown=${inactiveCountdown}
+      ></sprinkle-status-card>`
+    );
+
+    expect(driver.finders.stateLabel().text()?.trim()).toBe('off');
+    expect(driver.finders.countdown().exists()).toBe(false);
+  });
+
+  it('replaces the state label with a ticking countdown when active', async () => {
+    await driver.render(
+      html`<sprinkle-status-card
+        .valveSwitchState=${'on'}
+        .countdown=${activeCountdown}
+      ></sprinkle-status-card>`
+    );
+
+    expect(driver.finders.countdown().exists()).toBe(true);
+    expect(driver.finders.countdownTime().text()).toContain('00:45');
+    expect(driver.finders.stateLabel().exists()).toBe(false);
+  });
+
+  it('renders the countdown progress bar width from progress', async () => {
+    await driver.render(
+      html`<sprinkle-status-card
+        .valveSwitchState=${'on'}
+        .countdown=${activeCountdown}
+      ></sprinkle-status-card>`
+    );
+
+    const fill = driver.finders.progressFill();
+    expect(fill.exists()).toBe(true);
+    expect(fill.getAttribute('style')).toContain('width: 50%');
+  });
+});

--- a/packages/sprinkle/src/components/card-mini.ts
+++ b/packages/sprinkle/src/components/card-mini.ts
@@ -1,7 +1,7 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { fireEvent, fireHapticEvent } from '../utils/fireEvent';
-import { FlowRate } from '../services/valve-service';
+import { CountDown, FlowRate } from '../services/valve-service';
 import './optimistic-switch-button';
 
 const iconWaterOn = html`<svg
@@ -31,6 +31,7 @@ export class SprinkleCardMini extends LitElement {
   @property({ type: String }) batteryLevel: string = '';
   @property({ type: Object }) flowRate: FlowRate | null = null;
   @property({ type: Boolean }) isWaterRunning: boolean = false;
+  @property({ type: Object }) countdown: CountDown | null = null;
 
   handleToggleRequest() {
     fireEvent(this, 'toggle-valve');
@@ -89,7 +90,19 @@ export class SprinkleCardMini extends LitElement {
                 ${iconWaterOff}
               </span>
             </optimistic-switch-button>
-            <span>${this.valveSwitchState}</span>
+            ${this.countdown?.isActive
+              ? html`<div class="mini-countdown">
+                  <span class="mini-countdown-time"
+                    >⏱ ${this.countdown.formatted}</span
+                  >
+                  <div class="mini-progress">
+                    <div
+                      class="mini-progress-fill"
+                      style="width: ${this.countdown.progress}%"
+                    ></div>
+                  </div>
+                </div>`
+              : html`<span>${this.valveSwitchState}</span>`}
           </div>
 
           <div class="sprinkle-info">
@@ -216,6 +229,34 @@ export class SprinkleCardMini extends LitElement {
       100% {
         transform: rotate(360deg);
       }
+    }
+
+    .mini-countdown {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      width: 68px;
+    }
+
+    .mini-countdown-time {
+      font-family: monospace;
+      font-weight: bold;
+      color: var(--primary-color);
+    }
+
+    .mini-progress {
+      width: 100%;
+      height: 3px;
+      background: var(--divider-color);
+      border-radius: 2px;
+      overflow: hidden;
+    }
+
+    .mini-progress-fill {
+      height: 100%;
+      background: var(--primary-color);
+      transition: width 1s linear;
     }
   `;
 }

--- a/packages/sprinkle/src/services/valve-service.test.ts
+++ b/packages/sprinkle/src/services/valve-service.test.ts
@@ -559,4 +559,254 @@ describe('ValveService', () => {
       expect(formatTime(3599)).toBe('59:59'); // Just under 60 minutes
     });
   });
+
+  describe('timer entity integration', () => {
+    const timerConfig: SprinkleConfig = {
+      valve_entity: 'switch.mock_valve',
+      device_name: 'mock_device',
+      timer_entity: 'timer.mock_watering',
+    };
+
+    const mockTimerEntity = (
+      state: string,
+      attributes: Record<string, unknown> = {}
+    ): HassEntity => ({
+      entity_id: 'timer.mock_watering',
+      state,
+      last_changed: new Date().toISOString(),
+      last_updated: new Date().toISOString(),
+      attributes: attributes as HassEntityAttributeBase,
+      context: {} as Context,
+    });
+
+    const mockStates = (valveState: string, timerEntity?: HassEntity) => {
+      mockHaService.getEntityState.mockImplementation((entity) => {
+        if (entity === 'switch.mock_valve') return mockEntity(valveState);
+        if (entity === 'timer.mock_watering') {
+          return (timerEntity ?? {}) as HassEntity; // {} mirrors getEntityState for a missing entity
+        }
+        return {} as HassEntity;
+      });
+    };
+
+    beforeEach(() => {
+      valveService = new ValveService(mockHaService, timerConfig);
+      mockHaService.callService.mockResolvedValue({} as any);
+    });
+
+    describe('startTimedWateringOnce', () => {
+      it('starts the HA timer with the watering duration', async () => {
+        mockStates('off');
+        await valveService.startTimedWateringOnce(90);
+        expect(mockHaService.callService).toHaveBeenCalledWith(
+          'timer',
+          'start',
+          {
+            entity_id: 'timer.mock_watering',
+            duration: 90,
+          }
+        );
+      });
+
+      it('does not call timer.start when timer_entity is not configured', async () => {
+        valveService = new ValveService(mockHaService, mockConfig);
+        await valveService.startTimedWateringOnce(90);
+        const timerCalls = mockHaService.callService.mock.calls.filter(
+          ([domain]) => domain === 'timer'
+        );
+        expect(timerCalls).toHaveLength(0);
+      });
+
+      it('still starts watering when timer.start fails', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockHaService.callService.mockImplementation((domain) =>
+          domain === 'timer'
+            ? Promise.reject(new Error('timer unavailable'))
+            : Promise.resolve({} as any)
+        );
+
+        await expect(valveService.startTimedWateringOnce(90)).resolves.toBeDefined();
+        expect(mockHaService.callService).toHaveBeenCalledWith(
+          'mqtt',
+          'publish',
+          expect.anything()
+        );
+        // let the fire-and-forget rejection settle
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(warnSpy).toHaveBeenCalled();
+        warnSpy.mockRestore();
+      });
+    });
+
+    describe('turnValveOff', () => {
+      it('cancels the timer after turning the valve off', async () => {
+        await valveService.turnValveOff();
+        expect(mockHaService.callService).toHaveBeenCalledWith(
+          'timer',
+          'cancel',
+          {
+            entity_id: 'timer.mock_watering',
+          }
+        );
+      });
+
+      it('does not call timer.cancel when timer_entity is not configured', async () => {
+        valveService = new ValveService(mockHaService, mockConfig);
+        await valveService.turnValveOff();
+        const timerCalls = mockHaService.callService.mock.calls.filter(
+          ([domain]) => domain === 'timer'
+        );
+        expect(timerCalls).toHaveLength(0);
+      });
+    });
+
+    describe('toggleValve', () => {
+      it('cancels the timer when toggling an open valve', async () => {
+        mockStates('on');
+        await valveService.toggleValve();
+        expect(mockHaService.callService).toHaveBeenCalledWith(
+          'timer',
+          'cancel',
+          {
+            entity_id: 'timer.mock_watering',
+          }
+        );
+      });
+
+      it('does not cancel the timer when toggling a closed valve', async () => {
+        mockStates('off');
+        await valveService.toggleValve();
+        const timerCalls = mockHaService.callService.mock.calls.filter(
+          ([domain]) => domain === 'timer'
+        );
+        expect(timerCalls).toHaveLength(0);
+      });
+    });
+
+    describe('getTimerCountdown', () => {
+      const activeAttributes = (secondsFromNow: number, duration = '0:01:30') => ({
+        finishes_at: new Date(Date.now() + secondsFromNow * 1000).toISOString(),
+        duration,
+      });
+
+      it('returns an active countdown computed from finishes_at', () => {
+        mockStates('on', mockTimerEntity('active', activeAttributes(45)));
+
+        const countdown = valveService.getTimerCountdown();
+        expect(countdown).not.toBeNull();
+        expect(countdown!.isActive).toBe(true);
+        expect(countdown!.secondsRemaining).toBeGreaterThanOrEqual(44);
+        expect(countdown!.secondsRemaining).toBeLessThanOrEqual(46);
+        expect(countdown!.totalDuration).toBe(90);
+        expect(countdown!.progress).toBeGreaterThan(45);
+        expect(countdown!.progress).toBeLessThan(55);
+        expect(countdown!.formatted).toMatch(/^00:4[4-6]$/);
+      });
+
+      it('returns null when timer_entity is not configured', () => {
+        valveService = new ValveService(mockHaService, mockConfig);
+        mockHaService.getEntityState.mockReturnValue(mockEntity('on'));
+        expect(valveService.getTimerCountdown()).toBeNull();
+      });
+
+      it('returns null when the timer entity is missing', () => {
+        mockStates('on', undefined);
+        expect(valveService.getTimerCountdown()).toBeNull();
+      });
+
+      it.each(['idle', 'paused', 'unavailable'])(
+        'returns null when the timer state is %s',
+        (state) => {
+          mockStates('on', mockTimerEntity(state, activeAttributes(45)));
+          expect(valveService.getTimerCountdown()).toBeNull();
+        }
+      );
+
+      it('returns null when the valve is off even if the timer is active', () => {
+        mockStates('off', mockTimerEntity('active', activeAttributes(45)));
+        expect(valveService.getTimerCountdown()).toBeNull();
+      });
+
+      it('returns null when finishes_at is missing (paused/idle shape)', () => {
+        mockStates('on', mockTimerEntity('active', { duration: '0:01:30' }));
+        expect(valveService.getTimerCountdown()).toBeNull();
+      });
+
+      it('returns null when finishes_at is in the past', () => {
+        mockStates('on', mockTimerEntity('active', activeAttributes(-5)));
+        expect(valveService.getTimerCountdown()).toBeNull();
+      });
+
+      it('returns null when finishes_at is malformed', () => {
+        mockStates(
+          'on',
+          mockTimerEntity('active', { finishes_at: 'not-a-date', duration: '0:01:30' })
+        );
+        expect(valveService.getTimerCountdown()).toBeNull();
+      });
+
+      it('stays active with progress 0 when duration is malformed', () => {
+        mockStates(
+          'on',
+          mockTimerEntity('active', {
+            finishes_at: new Date(Date.now() + 45000).toISOString(),
+            duration: 'garbage',
+          })
+        );
+
+        const countdown = valveService.getTimerCountdown();
+        expect(countdown).not.toBeNull();
+        expect(countdown!.isActive).toBe(true);
+        expect(countdown!.totalDuration).toBe(0);
+        expect(countdown!.progress).toBe(0);
+      });
+    });
+
+    describe('getCountdownInfo with timer entity', () => {
+      it('prefers the timer countdown when the timer is active', () => {
+        mockStates(
+          'on',
+          mockTimerEntity('active', {
+            finishes_at: new Date(Date.now() + 45000).toISOString(),
+            duration: '0:01:30',
+          })
+        );
+
+        const countdown = valveService.getCountdownInfo();
+        expect(countdown.isActive).toBe(true);
+        expect(countdown.totalDuration).toBe(90);
+      });
+
+      it('falls back to the legacy computed countdown when the timer is idle', () => {
+        // externally-started timed run: z2m reports a cycle, HA timer knows nothing
+        valveService = new ValveService(mockHaService, {
+          ...timerConfig,
+          timed_irrigation_entity: 'sensor.mock_timed_irrigation',
+        });
+
+        const valveLastChanged = new Date(Date.now() - 60000).toISOString();
+        mockHaService.getEntityState.mockImplementation((entity) => {
+          if (entity === 'switch.mock_valve') {
+            return { ...mockEntity('on'), last_changed: valveLastChanged };
+          }
+          if (entity === 'timer.mock_watering') return mockTimerEntity('idle');
+          if (entity === 'sensor.mock_timed_irrigation') {
+            return {
+              ...mockEntity('on'),
+              entity_id: 'sensor.mock_timed_irrigation',
+              state:
+                "{'current_count': 1, 'total_number': 1, 'irrigation_duration': 300, 'irrigation_interval': 0}",
+            };
+          }
+          return {} as HassEntity;
+        });
+
+        const countdown = valveService.getCountdownInfo();
+        expect(countdown.isActive).toBe(true);
+        expect(countdown.totalDuration).toBe(300);
+        expect(countdown.secondsRemaining).toBeGreaterThan(235);
+        expect(countdown.secondsRemaining).toBeLessThanOrEqual(240);
+      });
+    });
+  });
 });

--- a/packages/sprinkle/src/services/valve-service.ts
+++ b/packages/sprinkle/src/services/valve-service.ts
@@ -44,6 +44,7 @@ export class ValveService {
   private deviceName: string;
 
   public weatherEntity: string | undefined;
+  private timerEntity: string | undefined;
   private timedIrrigationEntity: string | undefined;
   private quantitativeIrrigationEntity: string | undefined;
   private batteryEntity: string | undefined;
@@ -54,6 +55,7 @@ export class ValveService {
     this.haService = haService;
     this.valveEntity = config.valve_entity;
     this.deviceName = config.device_name;
+    this.timerEntity = config.timer_entity;
     this.timedIrrigationEntity = config.timed_irrigation_entity;
     this.quantitativeIrrigationEntity = config.quantitative_irrigation_entity;
     this.batteryEntity = config.battery_entity;
@@ -104,6 +106,9 @@ export class ValveService {
   }
 
   toggleValve(): Promise<ServiceCallResponse> {
+    if (this.isValveOn()) {
+      this.cancelTimer();
+    }
     return this.haService.callService('switch', 'toggle', {
       entity_id: this.valveEntity,
     });
@@ -115,10 +120,39 @@ export class ValveService {
     });
   }
 
-  turnValveOff(): Promise<ServiceCallResponse> {
-    return this.haService.callService('switch', 'turn_off', {
+  async turnValveOff(): Promise<ServiceCallResponse> {
+    const result = await this.haService.callService('switch', 'turn_off', {
       entity_id: this.valveEntity,
     });
+    this.cancelTimer();
+    return result;
+  }
+
+  /**
+   * Starts the HA timer helper alongside a timed watering.
+   * Failure-safe: a timer error must never break watering itself.
+   */
+  private startTimer(durationSeconds: number): void {
+    if (!this.timerEntity) return;
+    this.haService
+      .callService('timer', 'start', {
+        entity_id: this.timerEntity,
+        duration: durationSeconds,
+      })
+      .catch((error) => {
+        console.warn('Failed to start watering timer:', error);
+      });
+  }
+
+  private cancelTimer(): void {
+    if (!this.timerEntity) return;
+    this.haService
+      .callService('timer', 'cancel', {
+        entity_id: this.timerEntity,
+      })
+      .catch((error) => {
+        console.warn('Failed to cancel watering timer:', error);
+      });
   }
 
   /**
@@ -127,14 +161,16 @@ export class ValveService {
    * @param durationSeconds - Duration of the irrigation in seconds (max: 86400).
    * @returns A promise resolving the result of the MQTT publish call.
    */
-  startTimedWateringOnce(
+  async startTimedWateringOnce(
     durationSeconds: number
   ): Promise<ServiceCallResponse> {
-    return this.startTimedWatering({
+    const result = await this.startTimedWatering({
       durationSeconds,
       currentCount: 0,
       totalNumber: 1,
     });
+    this.startTimer(durationSeconds);
+    return result;
   }
 
   /**
@@ -288,7 +324,64 @@ export class ValveService {
     }
   }
 
+  /**
+   * Countdown derived from the HA timer helper entity (`timer_entity`).
+   * Returns an active countdown, or null whenever the timer path does not
+   * apply: no timer_entity configured, entity missing/unavailable, timer not
+   * `active` (idle/paused), no finishes_at, valve off, or time already
+   * elapsed. Callers fall back to the legacy computed countdown on null, so
+   * externally-started timed runs (z2m schedule, physical button) keep
+   * their countdown.
+   */
+  getTimerCountdown(): CountDown | null {
+    if (!this.timerEntity) return null;
+
+    const timer = this.haService.getEntityState(this.timerEntity);
+    if (timer?.state !== 'active' || !this.isValveOn()) return null;
+
+    const finishesAt = timer.attributes?.finishes_at;
+    if (typeof finishesAt !== 'string') return null;
+
+    const finishesAtMs = Date.parse(finishesAt);
+    if (!Number.isFinite(finishesAtMs)) return null;
+
+    const secondsRemaining = Math.ceil((finishesAtMs - Date.now()) / 1000);
+    if (secondsRemaining <= 0) return null;
+
+    const totalDuration = this.parseDurationAttribute(timer.attributes?.duration);
+
+    return {
+      secondsRemaining,
+      totalDuration,
+      isActive: true,
+      progress: totalDuration > 0
+        ? Math.min(100, Math.max(0, ((totalDuration - secondsRemaining) / totalDuration) * 100))
+        : 0,
+      formatted: this.formatTime(secondsRemaining),
+    };
+  }
+
+  /** Parses the timer `duration` attribute ("H:MM:SS") into seconds; 0 if malformed. */
+  private parseDurationAttribute(duration: unknown): number {
+    if (typeof duration === 'number' && Number.isFinite(duration)) {
+      return duration;
+    }
+    if (typeof duration !== 'string' || duration === '') return 0;
+
+    const parts = duration.split(':').map(Number);
+    if (parts.length !== 3 || parts.some((part) => !Number.isFinite(part))) {
+      return 0;
+    }
+    const [hours, minutes, seconds] = parts;
+    return hours * 3600 + minutes * 60 + seconds;
+  }
+
   getCountdownInfo(): CountDown {
+    const timerCountdown = this.getTimerCountdown();
+    if (timerCountdown) {
+      return timerCountdown;
+    }
+
     const secondsRemaining = this.getCurrentCycleTimeRemaining();
     
     const irrigationState = this.timedIrrigation?.state || '{}';

--- a/packages/sprinkle/src/types/config.ts
+++ b/packages/sprinkle/src/types/config.ts
@@ -14,6 +14,7 @@ export interface SprinkleConfig {
     duration_max?: number;
     timed_irrigation_entity?: string;
     quantitative_irrigation_entity?: string;
+    timer_entity?: string;
 }
 
 export type Mode = 'duration' | 'volume';


### PR DESCRIPTION
## What changed
- New optional `timer_entity` config option pointing at an HA [timer helper](https://www.home-assistant.io/integrations/timer/).
- `ValveService`: starting a duration-based watering also calls `timer.start` with the chosen duration; `turnValveOff()` / toggle-off call `timer.cancel`. Both are failure-safe — a timer service error never breaks watering itself.
- New `getTimerCountdown()`: derives the countdown from the timer's server-side `finishes_at`, so every client shows the same ticking time and it survives page reloads. Returns `null` whenever the timer path doesn't apply (unset/missing entity, timer not `active`, valve off, elapsed) — `getCountdownInfo()` then falls back to the existing computed countdown, so externally-started timed runs (z2m schedule, physical button) keep their countdown in the more-info dialog.
- Mini card: while a timer-driven watering is active, the on/off label under the tap button is replaced with `⏱ MM:SS` + a slim progress bar, ticked by a single guarded 1s interval in `sprinkle-card` (cleaned up on disconnect). Without `timer_entity`, rendering is unchanged.
- README: documents the option with timer-helper + cancel-automation setup snippets.

## Tests
- 159 tests passing (24 new): timer start/cancel service calls, countdown math from `finishes_at`, fallback contract, valve-off suppression, malformed-attribute edge cases, mini-card rendering states.
- `tsc --noEmit` clean; production build compiles. Changed files lint clean (pre-existing lint errors elsewhere untouched).

## Deployed
Already running on the home Pi via alexd-homeserver PR AlexDubok/alexd-homeserver#62 (bundle built from 79a7bd5): timer entities + cancel automations verified live after HA restart.

## Notes
- Duration-based, card-initiated watering only by design; volume mode unchanged.
- Backward compatible: cards without `timer_entity` behave exactly as before.